### PR TITLE
Add missing requests dependency to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "jinja2",
     "python-dotenv",
     "gradio",
+    "requests",
     "pathlib2>=2.3.0; python_version < '3.4'",
 ]
 


### PR DESCRIPTION
The requests module is imported in relay_provider.py but was not listed in dependencies. Adding this package to fix the CI test failures.

Test Plan:
uv run pytest tests/ -v