### PR TITLE
Add Basic Hydra Config support

### DIFF
--- a/configs/kernel_agent/additional_code_config.yaml
+++ b/configs/kernel_agent/additional_code_config.yaml
@@ -1,0 +1,15 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+additional_code: examples/dropout_residual/additional_code.py

--- a/configs/ui/basic_config.yaml
+++ b/configs/ui/basic_config.yaml
@@ -1,0 +1,16 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+port: 8085
+host: localhost

--- a/examples/triton_04_fused_dropout_residual.py
+++ b/examples/triton_04_fused_dropout_residual.py
@@ -15,39 +15,37 @@
 
 """Fused dropout-residual operation example for KernelAgent."""
 
-import argparse
 import sys
 import time
 import os
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+import hydra
+from pathlib import Path
+
 from dotenv import load_dotenv
+from omegaconf import DictConfig
 from triton_kernel_agent import TritonKernelAgent
 
 
-def main():
+@hydra.main(
+    version_base=None,
+    config_path=str(Path(__file__).resolve().parent.parent / "configs/kernel_agent"),
+    config_name="additional_code_config",
+)
+def main(cfg: DictConfig):
     """Generate and test a fused dropout-residual kernel."""
-
-    # Load additional code if working directory provided
-    parser = argparse.ArgumentParser(
-        description="Generate fused dropout-residual kernel with optional additional code."
-    )
-    parser.add_argument(
-        "--additional-code", type=str, help="Path to additional reference code file"
-    )
-    args = parser.parse_args()
-
     additional_code = None
-    if args.additional_code:
-        if not os.path.exists(args.additional_code):
-            print(f"Error: File {args.additional_code} does not exist")
+    if additional_code_path := cfg.additional_code:
+        if not os.path.exists(additional_code_path):
+            print(f"Error: File {additional_code_path} does not exist")
             sys.exit(1)
 
         try:
-            with open(args.additional_code, "r") as f:
+            with open(additional_code_path, "r") as f:
                 additional_code = f.read()
-            print(f"Loaded additional code from: {args.additional_code}")
+            print(f"Loaded additional code from: {additional_code_path}")
         except Exception as e:
             print(f"Error: Failed to read additional code: {e}")
             sys.exit(1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,8 @@ classifiers = [
 ]
 
 dependencies = [
+    "hydra-core",
+    "omegaconf",
     "openai",
     "jinja2",
     "python-dotenv",

--- a/scripts/triton_ui.py
+++ b/scripts/triton_ui.py
@@ -15,19 +15,25 @@
 
 """Gradio UI for Triton Kernel Agent."""
 
-import argparse
+import logging
 import os
 import time
 import traceback
 from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
 
+import hydra
+from omegaconf import DictConfig
+
 import gradio as gr
 from dotenv import load_dotenv
 
-
 from triton_kernel_agent import TritonKernelAgent
 from triton_kernel_agent.providers.models import AVAILABLE_MODELS
+
+# Turn off noisy HTTPX logging
+httpx_logger = logging.getLogger("httpx")
+httpx_logger.setLevel(logging.WARNING)
 
 
 KERNELBENCH_BASE_PATH = (
@@ -550,14 +556,15 @@ def _create_app() -> gr.Blocks:
     return app
 
 
-def main():
+@hydra.main(
+    version_base=None,
+    config_path=str(Path(__file__).resolve().parent.parent / "configs/ui"),
+    config_name="basic_config",
+)
+def main(cfg: DictConfig):
     """Create and launch the Gradio interface"""
-    parser = argparse.ArgumentParser(description="Triton Kernel Agent UI")
-    parser.add_argument("--port", type=int, default=8085, help="Port to run the UI on")
-    parser.add_argument("--host", type=str, default="localhost", help="Host to bind to")
-    args = parser.parse_args()
-
     app = _create_app()
+    port = cfg.port
 
     # Check if running on Meta devserver (has Meta SSL certs)
     meta_keyfile = "/var/facebook/x509_identities/server.pem"
@@ -569,14 +576,14 @@ def main():
     if is_meta_devserver:
         # Meta devserver configuration
         server_name = os.uname()[1]  # Get devserver hostname
-        print(f"🌐 Opening on Meta devserver: https://{server_name}:{args.port}/")
+        print(f"🌐 Opening on Meta devserver: https://{server_name}:{port}/")
         print("💡 Make sure you're connected to Meta VPN to access the demo")
 
         app.launch(
             share=False,
             show_error=True,
             server_name=server_name,
-            server_port=args.port,
+            server_port=port,
             ssl_keyfile=meta_keyfile,
             ssl_certfile=meta_keyfile,
             ssl_verify=False,
@@ -585,16 +592,18 @@ def main():
         )
     else:
         # Local development configuration
-        print(f"🌐 Opening locally: http://{args.host}:{args.port}/")
+        host = cfg.host
+
+        print(f"🌐 Opening locally: http://{host}:{port}/")
         print(
-            f"🚨 IMPORTANT: If Chrome shows blank page, try Safari: open -a Safari http://{args.host}:{args.port}/ 🚨"
+            f"🚨 IMPORTANT: If Chrome shows blank page, try Safari: open -a Safari http://{host}:{port}/ 🚨"
         )
 
         app.launch(
             share=False,
             show_error=True,
-            server_name=args.host,
-            server_port=args.port,
+            server_name=host,
+            server_port=port,
             show_api=False,
             inbrowser=True,  # Auto-open browser for local development
         )


### PR DESCRIPTION
We currently have a bunch of `argparsers` scattered around. As we land more pipeline features, this will grow unwieldy and we'll need a unified config for controlling all the individual agent components. 

I'm not 100% sold that I want to use Hydra, but it's a simple onramp/offramp if we want to use something else (Fiddle, manual dataclass factories, etc.) and it's better than manual parsing

This PR adds an initial [Hydra](https://hydra.cc/) setup and migrating the existing cli's.

_Note: We can follow up this PR to use [StructuredConfigs](https://hydra.cc/docs/tutorials/structured_config/hierarchical_static_config/) once the cli is a bit more stable_

---
### Manual tests
`scripts/triton_ui.py`
``` bash
kernel-agent
kernel-agent port=8086

python scripts/triton_ui.py
python scripts/triton_ui.py port=8086
```

`examples/triton_04_fused_dropout_residual.py`
```
python examples/triton_04_fused_dropout_residual.py
python examples/triton_04_fused_dropout_residual.py additional_code=""
```

