### PR TITLE
Integrating Custom Backends via JSON Platform Configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,12 @@ Every stage writes artifacts to a run directory under `.optimize/<run_id>/`, inc
 - **GPU Requirements (one of the following):**
   - **CUDA**: NVIDIA GPU with CUDA support
   - **XPU**: Intel GPU with oneAPI support (Arc, Data Center GPUs, or integrated Xe graphics)
+  - **Custom GPU**: Make sure that the GPU is supported by `torch.accelerator`
 - Triton (installed separately: `pip install triton` or nightly from source)
 - PyTorch (https://pytorch.org/get-started/locally/)
 - LLM provider ([OpenAI](https://openai.com/api/), [Anthropic](https://www.anthropic.com/), or a self-hosted relay)
+
+**Important Note for custom gpu**: Please install correlated version of PyTorch and Triton!!!
 
 ### Install
 ```bash
@@ -234,6 +237,33 @@ When targeting Intel XPU, KernelAgent automatically:
 - Generates appropriate device availability checks
 - Removes CUDA-specific patterns from generated code
 
+### Custom Platforms via JSON (Optional)
+
+You can add/override platform configs via a JSON file loaded at import time:
+
+```bash
+export KERNELAGENT_PLATFORM_JSON=/abs/path/to/platforms.json
+```
+
+JSON format (top-level is a mapping; keys are platform names used by `--target-platform`):
+
+```json
+// platforms.json
+{
+  "npu": {
+    "name": "npu",
+    "device_string": "npu",
+    "guidance_block": "...",
+    "kernel_guidance": "...",
+    "cuda_hacks_to_strip": []
+  }
+}
+```
+
+Notes:
+- Set `KERNELAGENT_PLATFORM_JSON` before starting any KernelAgent/Fuser CLI.
+- Set the platform name by `--target-platform` or `target_platform` explicitly (e.g `python -m Fuser.auto_agent --problem /abs/path/to/problem.py --target-platform npu`).
+
 ### Verifying Platform Setup
 ```python
 # Check CUDA availability
@@ -242,6 +272,9 @@ print("CUDA available:", torch.cuda.is_available())
 
 # Check XPU availability
 print("XPU available:", hasattr(torch, 'xpu') and torch.xpu.is_available())
+
+# Check custom gpu availability (Suppose the name is NPU)
+print("NPU available:", torch.accelerator.is_available() and torch.accelerator.current_accelerator().type == 'npu')
 ```
 
 ## Run Artifacts

--- a/triton_kernel_agent/agent.py
+++ b/triton_kernel_agent/agent.py
@@ -18,7 +18,7 @@ import os
 import json
 import re
 from pathlib import Path
-from typing import Any
+from typing import Any, Union
 from datetime import datetime
 import logging
 from dotenv import load_dotenv
@@ -40,7 +40,7 @@ class TritonKernelAgent:
         model_name: str | None = None,
         high_reasoning_effort: bool = True,
         preferred_provider: BaseProvider | None = None,
-        target_platform: PlatformConfig | None = None,
+        target_platform: Union[PlatformConfig, str] | None = None,
         no_cusolver: bool = False,
         test_timeout_s: int = 30,
     ):
@@ -87,9 +87,12 @@ class TritonKernelAgent:
         self.log_dir.mkdir(exist_ok=True, parents=True)
 
         # Normalize to PlatformConfig
-        self._platform_config = (
-            target_platform if target_platform else get_platform("cuda")
-        )
+        if not target_platform:
+            target_platform = get_platform("cuda")
+        elif isinstance(target_platform, str):
+            target_platform = get_platform(target_platform)
+        self._platform_config = target_platform
+
         self.no_cusolver = no_cusolver
         self.test_timeout_s = test_timeout_s
 

--- a/triton_kernel_agent/templates/test_generation.j2
+++ b/triton_kernel_agent/templates/test_generation.j2
@@ -120,9 +120,12 @@ def test_kernel():
 {% if device_string == "xpu" %}
         if not hasattr(torch, 'xpu') or not torch.xpu.is_available():
             raise RuntimeError("Intel XPU not available. Install PyTorch with Intel GPU support.")
-{% else %}
+{% elif device_string == "cuda" %}
         if not torch.cuda.is_available():
             raise RuntimeError("CUDA not available")
+{% else %}
+        if not torch.accelerator.is_available():
+            raise RuntimeError(f"Device '{device}' not available: {e}")
 {% endif %}
 
         # Create test data using EXACT specifications from problem description


### PR DESCRIPTION
## Summary

This change extends KernelAgent’s multi-platform support by allowing users to integrate a **custom backend** (or override existing platform settings) via an external JSON file. The JSON is loaded at import time and merged into the in-memory platform registry, enabling new `--target-platform <name>` values (e.g., `npu`) without modifying repository code.

## Motivation

KernelAgent already supports CUDA and Intel XPU via a built-in `PlatformConfig` registry. However, adding a new backend (e.g., an NPU platform) typically requires:

- Modifying the in-repo platform registry,
- Updating prompts and device checks,
- Shipping and maintaining these changes for each new backend.

This PR introduces a lightweight escape hatch: **JSON-defined platform configs** that can be set per-environment. It lowers the friction for downstream teams with custom backends (rocm, tpu, npu, etc.) experimenting.

## Usage

### Define a custom platform (example: NPU)

1) Create a JSON file:

```json
{
  "npu": {
    "name": "npu",
    "device_string": "npu",
    "guidance_block": "...",
    "kernel_guidance": "...",
    "cuda_hacks_to_strip": []
  }
}
```

2) Export the env var (must be set before importing KernelAgent modules):

```bash
export KERNELAGENT_PLATFORM_JSON=/abs/path/to/platforms.json
```

3) Select the platform via existing CLI flags (examples shown in README):

```bash
python -m Fuser.auto_agent --problem /abs/path/to/problem.py --target-platform npu
```

### Programmatic usage

```python
from triton_kernel_agent import TritonKernelAgent

agent = TritonKernelAgent(
    num_workers=4,
    max_rounds=8,
    model_name="gpt-5",
    target_platform="npu",  # can now pass a string
)
```

## Testing

This PR does not add new unit tests since it requires external JSON files, but the following verification has been tested:

- [x] Tested on CUDA (default behavior unchanged)
- [x] Tested on a custom backend (NPU)
- [x] CLI --target-platform  flag works for auto_agent, pipeline, and cli
- [x] UI platform dropdown works in all three UIs