### PR TITLE
Make optimization template paths configurable

### DIFF
--- a/examples/configs/nvidia.yaml
+++ b/examples/configs/nvidia.yaml
@@ -35,3 +35,8 @@ platform:
   roofline_analyzer: nvidia
   bottleneck_analyzer: nvidia
   rag_prescriber: nvidia
+
+templates:
+  kernel_optimization: triton_kernel_agent/templates/kernel_optimization.j2
+  reflexion_prompt: triton_kernel_agent/templates/reflexion_prompt.j2
+  triton_guidelines: triton_kernel_agent/templates/triton_guidelines.j2

--- a/triton_kernel_agent/opt_manager.py
+++ b/triton_kernel_agent/opt_manager.py
@@ -119,6 +119,9 @@ class OptimizationManager:
         self.bottleneck_override = bottleneck_override
         self.worker_kwargs = worker_kwargs
 
+        # Store template overrides (also stays in worker_kwargs for forwarding)
+        self.templates_config = worker_kwargs.get("templates")
+
         # Setup logging
         self.logger = self._setup_logging()
 

--- a/triton_kernel_agent/opt_worker.py
+++ b/triton_kernel_agent/opt_worker.py
@@ -96,6 +96,8 @@ class OptimizationWorker:
         platform_components: dict[str, Any] | None = None,
         # Registry-driven platform config (string names) ───────────
         platform_config: dict[str, str] | None = None,
+        # Template overrides from YAML config ─────────────────────
+        templates: dict[str, str] | None = None,
     ):
         """
         Initialize the optimization worker.
@@ -147,6 +149,9 @@ class OptimizationWorker:
         # Platform components (registry-resolved, may be empty)
         self._platform = platform_components or {}
         self._platform_config = platform_config or {}
+
+        # Template overrides (forwarded to PromptManager)
+        self.templates_config = templates
 
         # BeamSearch parameters
         self.bottleneck_id = bottleneck_id
@@ -254,7 +259,10 @@ class OptimizationWorker:
         """
         # Prompt manager (platform-aware, but not hardware-specific)
         platform_config = get_platform(self.target_platform)
-        self.prompt_manager = PromptManager(target_platform=platform_config)
+        self.prompt_manager = PromptManager(
+            target_platform=platform_config,
+            template_overrides=self.templates_config,
+        )
 
         # Benchmarking
         from triton_kernel_agent.opt_worker_component.benchmarking.benchmark import (
@@ -327,8 +335,8 @@ class OptimizationWorker:
                 logger=self.logger,
             )
 
-        # RAG prescriber
-        if "rag_prescriber" in self._platform:
+        # RAG prescriber (only when use_rag is enabled)
+        if self.use_rag and "rag_prescriber" in self._platform:
             self.rag_prescriber = self._platform["rag_prescriber"]
         elif self.use_rag:
             try:

--- a/triton_kernel_agent/platform/__init__.py
+++ b/triton_kernel_agent/platform/__init__.py
@@ -44,6 +44,7 @@ from triton_kernel_agent.platform.interfaces import (
     KernelVerifier,
     RAGPrescriberBase,
     RooflineAnalyzerBase,
+    RooflineResult,
     WorkerRunner,
 )
 from triton_kernel_agent.platform.nvidia import (
@@ -77,6 +78,7 @@ __all__ = [
     "AcceleratorSpecsProvider",
     "KernelProfilerBase",
     "RooflineAnalyzerBase",
+    "RooflineResult",
     "BottleneckAnalyzerBase",
     "RAGPrescriberBase",
     # NVIDIA implementations (manager)

--- a/triton_kernel_agent/platform/interfaces.py
+++ b/triton_kernel_agent/platform/interfaces.py
@@ -22,6 +22,7 @@ manager. Implement these to support a new backend.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -200,22 +201,39 @@ class KernelProfilerBase(ABC):
         ...
 
 
+@dataclass(frozen=True)
+class RooflineResult:
+    """Lightweight, dependency-free roofline analysis result.
+
+    Platform implementations may return their own richer type from
+    ``RooflineAnalyzerBase.analyze()`` as long as it satisfies the same
+    attribute protocol.  This dataclass is the canonical minimal
+    implementation and is used by the noop platform.
+    """
+
+    efficiency_pct: float = 0.0
+    compute_sol_pct: float = 0.0
+    memory_sol_pct: float = 0.0
+    bottleneck: str = "unknown"
+    at_roofline: bool = False
+    headroom_pct: float = 100.0
+    uses_tensor_cores: bool = False
+    warnings: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
 class RooflineAnalyzerBase(ABC):
     """Classifies a kernel as memory-bound, compute-bound, or underutilised."""
 
     @abstractmethod
-    def analyze(self, ncu_metrics: dict[str, Any]) -> Any:
-        """Analyse profiler metrics and return a roofline result.
-
-        The return value should be compatible with ``RooflineResult``
-        (has ``efficiency_pct``, ``compute_sol_pct``, ``memory_sol_pct``,
-        ``bottleneck``, ``at_roofline``, ``headroom_pct``,
-        ``uses_tensor_cores``, ``to_dict()``).
-        """
+    def analyze(self, ncu_metrics: dict[str, Any]) -> RooflineResult:
+        """Analyse profiler metrics and return a roofline result."""
         ...
 
     @abstractmethod
-    def should_stop(self, result: Any) -> tuple[bool, str]:
+    def should_stop(self, result: RooflineResult) -> tuple[bool, str]:
         """Whether optimisation should terminate (at roofline or converged).
 
         Returns:
@@ -238,7 +256,7 @@ class BottleneckAnalyzerBase(ABC):
         kernel_code: str,
         ncu_metrics: dict[str, Any],
         round_num: int = 0,
-        roofline_result: Any | None = None,
+        roofline_result: RooflineResult | None = None,
     ) -> list[Any]:
         """Analyse kernel bottlenecks.
 

--- a/triton_kernel_agent/platform/noop.py
+++ b/triton_kernel_agent/platform/noop.py
@@ -26,6 +26,7 @@ import logging
 from pathlib import Path
 from typing import Any
 
+from kernel_perf_agent.kernel_opt.roofline.ncu_roofline import RooflineResult
 from triton_kernel_agent.platform.interfaces import (
     AcceleratorSpecsProvider,
     BottleneckAnalyzerBase,
@@ -176,16 +177,16 @@ class NoOpProfiler(KernelProfilerBase):
 class NoOpRooflineAnalyzer(RooflineAnalyzerBase):
     """Reports zero efficiency and always signals stop."""
 
-    def analyze(self, ncu_metrics: dict[str, Any]) -> Any:
-        return {
-            "efficiency_pct": 0.0,
-            "compute_sol_pct": 0.0,
-            "memory_sol_pct": 0.0,
-            "bottleneck": "unknown",
-            "at_roofline": False,
-            "headroom_pct": 100.0,
-            "uses_tensor_cores": False,
-        }
+    def analyze(self, ncu_metrics: dict[str, Any]) -> RooflineResult:
+        return RooflineResult(
+            efficiency_pct=0.0,
+            compute_sol_pct=0.0,
+            memory_sol_pct=0.0,
+            bottleneck="unknown",
+            at_roofline=False,
+            headroom_pct=100.0,
+            uses_tensor_cores=False,
+        )
 
     def should_stop(self, result: Any) -> tuple[bool, str]:
         return True, "noop roofline — always stop"

--- a/triton_kernel_agent/platform/noop.py
+++ b/triton_kernel_agent/platform/noop.py
@@ -26,7 +26,6 @@ import logging
 from pathlib import Path
 from typing import Any
 
-from kernel_perf_agent.kernel_opt.roofline.ncu_roofline import RooflineResult
 from triton_kernel_agent.platform.interfaces import (
     AcceleratorSpecsProvider,
     BottleneckAnalyzerBase,
@@ -35,6 +34,7 @@ from triton_kernel_agent.platform.interfaces import (
     KernelVerifier,
     RAGPrescriberBase,
     RooflineAnalyzerBase,
+    RooflineResult,
     WorkerRunner,
 )
 
@@ -178,15 +178,7 @@ class NoOpRooflineAnalyzer(RooflineAnalyzerBase):
     """Reports zero efficiency and always signals stop."""
 
     def analyze(self, ncu_metrics: dict[str, Any]) -> RooflineResult:
-        return RooflineResult(
-            efficiency_pct=0.0,
-            compute_sol_pct=0.0,
-            memory_sol_pct=0.0,
-            bottleneck="unknown",
-            at_roofline=False,
-            headroom_pct=100.0,
-            uses_tensor_cores=False,
-        )
+        return RooflineResult()
 
     def should_stop(self, result: Any) -> tuple[bool, str]:
         return True, "noop roofline — always stop"

--- a/triton_kernel_agent/prompt_manager.py
+++ b/triton_kernel_agent/prompt_manager.py
@@ -37,10 +37,14 @@ class PromptManager:
     for test generation, kernel generation, and kernel refinement.
     """
 
+    # Templates that can be overridden via config
+    _OVERRIDABLE = {"kernel_optimization", "reflexion_prompt", "triton_guidelines"}
+
     def __init__(
         self,
         templates_dir: str | None = None,
         target_platform: PlatformConfig | None = None,
+        template_overrides: dict[str, str] | None = None,
     ):
         """
         Initialize the prompt manager.
@@ -48,6 +52,10 @@ class PromptManager:
         Args:
             templates_dir: Path to the templates directory. If None, uses default.
             target_platform: Target platform PlatformConfig
+            template_overrides: Optional dict mapping logical template names to
+                absolute file paths for custom .j2 files.  Only the optimization
+                templates (kernel_optimization, reflexion_prompt, triton_guidelines)
+                can be overridden; other keys are ignored.
         """
         if not JINJA2_AVAILABLE:
             raise ImportError(
@@ -63,6 +71,8 @@ class PromptManager:
         else:
             # Default to bundled templates directory within the package
             self.templates_dir = Path(__file__).parent / "templates"
+
+        self._template_overrides = template_overrides
 
         if not self.templates_dir.exists():
             raise FileNotFoundError(
@@ -80,7 +90,13 @@ class PromptManager:
         self._load_templates()
 
     def _load_templates(self):
-        """Load all available templates."""
+        """Load all available templates.
+
+        For the three optimization-related templates (kernel_optimization,
+        reflexion_prompt, triton_guidelines), an override path supplied via
+        ``template_overrides`` takes precedence over the bundled default.
+        Non-optimization templates are always loaded from ``templates_dir``.
+        """
         self.templates = {}
 
         # Define template mappings (required templates)
@@ -99,17 +115,43 @@ class PromptManager:
 
         # Load required templates
         for template_name, template_file in template_files.items():
-            template_path = self.templates_dir / template_file
-            if template_path.exists():
-                self.templates[template_name] = self.env.get_template(template_file)
+            override_path = (self._template_overrides or {}).get(template_name)
+            if override_path and template_name in self._OVERRIDABLE:
+                # Load from absolute path
+                p = Path(override_path)
+                if not p.exists():
+                    raise FileNotFoundError(
+                        f"Template override not found: {p}"
+                    )
+                self.templates[template_name] = self.env.from_string(p.read_text())
             else:
-                raise FileNotFoundError(f"Template file not found: {template_path}")
+                # Default: load from templates_dir
+                template_path = self.templates_dir / template_file
+                if template_path.exists():
+                    self.templates[template_name] = self.env.get_template(
+                        template_file
+                    )
+                else:
+                    raise FileNotFoundError(
+                        f"Template file not found: {template_path}"
+                    )
 
         # Load optional templates
         for template_name, template_file in optional_template_files.items():
-            template_path = self.templates_dir / template_file
-            if template_path.exists():
-                self.templates[template_name] = self.env.get_template(template_file)
+            override_path = (self._template_overrides or {}).get(template_name)
+            if override_path and template_name in self._OVERRIDABLE:
+                p = Path(override_path)
+                if not p.exists():
+                    raise FileNotFoundError(
+                        f"Template override not found: {p}"
+                    )
+                self.templates[template_name] = self.env.from_string(p.read_text())
+            else:
+                template_path = self.templates_dir / template_file
+                if template_path.exists():
+                    self.templates[template_name] = self.env.get_template(
+                        template_file
+                    )
 
     def render_test_generation_prompt(
         self, problem_description: str, provided_test_code: str | None = None

--- a/triton_kernel_agent/prompt_manager.py
+++ b/triton_kernel_agent/prompt_manager.py
@@ -120,21 +120,15 @@ class PromptManager:
                 # Load from absolute path
                 p = Path(override_path)
                 if not p.exists():
-                    raise FileNotFoundError(
-                        f"Template override not found: {p}"
-                    )
+                    raise FileNotFoundError(f"Template override not found: {p}")
                 self.templates[template_name] = self.env.from_string(p.read_text())
             else:
                 # Default: load from templates_dir
                 template_path = self.templates_dir / template_file
                 if template_path.exists():
-                    self.templates[template_name] = self.env.get_template(
-                        template_file
-                    )
+                    self.templates[template_name] = self.env.get_template(template_file)
                 else:
-                    raise FileNotFoundError(
-                        f"Template file not found: {template_path}"
-                    )
+                    raise FileNotFoundError(f"Template file not found: {template_path}")
 
         # Load optional templates
         for template_name, template_file in optional_template_files.items():
@@ -142,16 +136,12 @@ class PromptManager:
             if override_path and template_name in self._OVERRIDABLE:
                 p = Path(override_path)
                 if not p.exists():
-                    raise FileNotFoundError(
-                        f"Template override not found: {p}"
-                    )
+                    raise FileNotFoundError(f"Template override not found: {p}")
                 self.templates[template_name] = self.env.from_string(p.read_text())
             else:
                 template_path = self.templates_dir / template_file
                 if template_path.exists():
-                    self.templates[template_name] = self.env.get_template(
-                        template_file
-                    )
+                    self.templates[template_name] = self.env.get_template(template_file)
 
     def render_test_generation_prompt(
         self, problem_description: str, provided_test_code: str | None = None


### PR DESCRIPTION
Currently the templates used in optimization are hardcoded. This PR makes them configurable via yaml


_[OT] There is also a small typing change to RooflineResult unrelated to this PR that just adds an interface_

---

```
python examples/run_opt_manager.py --kernel-dir examples/optimize_01_matvec --max-rounds 1 --strategy nvidia
```