### PR TITLE
Add support for test generation when manual test is provided

### DIFF
--- a/Fuser/auto_agent.py
+++ b/Fuser/auto_agent.py
@@ -350,6 +350,7 @@ class AutoKernelRouter:
         use_router_cache: bool = True,
         no_cusolver: bool = False,
         test_timeout_s: int = 30,
+        test_code: str | None = None,
     ) -> None:
         self.ka_model = ka_model
         self.ka_num_workers = ka_num_workers
@@ -376,8 +377,11 @@ class AutoKernelRouter:
         self.use_router_cache = use_router_cache
         self.no_cusolver = no_cusolver
         self.test_timeout_s = test_timeout_s
+        self.test_code = test_code
 
-    def _solve_with_kernelagent(self, problem_code: str) -> RouteResult:
+    def _solve_with_kernelagent(
+        self, problem_code: str, test_code: str | None = None
+    ) -> RouteResult:
         agent = TritonKernelAgent(
             num_workers=self.ka_num_workers,
             max_rounds=self.ka_max_rounds,
@@ -391,7 +395,7 @@ class AutoKernelRouter:
             # Ensure exceptions in KernelAgent do not abort routing; return a structured failure
             try:
                 res = agent.generate_kernel(
-                    problem_description=problem_code, test_code=None
+                    problem_description=problem_code, test_code=test_code
                 )
             except BaseException as exc:
                 return RouteResult(
@@ -480,8 +484,10 @@ class AutoKernelRouter:
             details=res,
         )
 
-    def solve(self, problem_path: Path) -> RouteResult:
+    def solve(self, problem_path: Path, test_code: str | None = None) -> RouteResult:
         code = problem_path.read_text(encoding="utf-8")
+        # Use explicitly-passed test_code, falling back to the instance default
+        test_code = test_code if test_code is not None else self.test_code
         cx = analyze_problem_code(code)
 
         # Default heuristic-only decision used STRICTLY as a last-resort tie-breaker
@@ -563,7 +569,7 @@ class AutoKernelRouter:
 
         # Execute per strategy with symmetric fallback governed by allow_fallback
         if strategy == "kernelagent":
-            ka_res = self._solve_with_kernelagent(code)
+            ka_res = self._solve_with_kernelagent(code, test_code=test_code)
             if ka_res.success or not self.allow_fallback:
                 return ka_res
             return self._solve_with_fuser(problem_path)
@@ -571,9 +577,9 @@ class AutoKernelRouter:
             fuser_res = self._solve_with_fuser(problem_path)
             if fuser_res.success or not self.allow_fallback:
                 return fuser_res
-            return self._solve_with_kernelagent(code)
+            return self._solve_with_kernelagent(code, test_code=test_code)
         elif strategy == "kernel_then_fuser":
-            ka_res = self._solve_with_kernelagent(code)
+            ka_res = self._solve_with_kernelagent(code, test_code=test_code)
             if ka_res.success or not self.allow_fallback:
                 return ka_res
             return self._solve_with_fuser(problem_path)
@@ -581,7 +587,7 @@ class AutoKernelRouter:
             fuser_res = self._solve_with_fuser(problem_path)
             if fuser_res.success or not self.allow_fallback:
                 return fuser_res
-            return self._solve_with_kernelagent(code)
+            return self._solve_with_kernelagent(code, test_code=test_code)
 
     # -------- LLM decision helper --------
     def _llm_decide_route(
@@ -715,6 +721,11 @@ def main(argv: list[str] | None = None) -> int:
     )
     p.add_argument("--problem", required=True, help="Absolute path to the problem file")
     p.add_argument(
+        "--test-paths",
+        default=None,
+        help="Path to an additional test file for the kernel agent",
+    )
+    p.add_argument(
         "--config",
         default=None,
         help="Path to AutoAgentRouter config file. When provided, all other CLI args are ignored.",
@@ -774,12 +785,21 @@ def main(argv: list[str] | None = None) -> int:
         print(f"problem not found: {problem_path}", file=sys.stderr)
         return 2
 
+    # Read test code from --test-paths if provided
+    test_code: str | None = None
+    if args.test_paths:
+        tp_path = Path(args.test_paths).resolve()
+        if not tp_path.is_file():
+            print(f"test file not found: {tp_path}", file=sys.stderr)
+            return 2
+        test_code = tp_path.read_text(encoding="utf-8")
+
     if args.config is not None:
         print(
             f"Using config file: {args.config} (other CLI args are ignored)",
             file=sys.stderr,
         )
-        router = AutoKernelRouter(config=args.config)
+        router = AutoKernelRouter(config=args.config, test_code=test_code)
     else:
         router = AutoKernelRouter(
             ka_model=args.ka_model,
@@ -806,6 +826,7 @@ def main(argv: list[str] | None = None) -> int:
             use_router_cache=(not args.no_router_cache),
             no_cusolver=args.no_cusolver,
             test_timeout_s=args.run_timeout_s,
+            test_code=test_code,
         )
 
     try:

--- a/Fuser/config/autoagent_default.yml
+++ b/Fuser/config/autoagent_default.yml
@@ -34,3 +34,4 @@ ignore_router_config: false
 use_router_cache: true
 no_cusolver: false
 test_timeout_s: 30
+test_code: null

--- a/triton_kernel_agent/agent.py
+++ b/triton_kernel_agent/agent.py
@@ -496,7 +496,9 @@ def kernel_function(*args, **kwargs):
             self.logger.info("Appending provided test code")
             test_code_list.append(test_code)
         if not test_code_list:
-            raise ValueError("No test code: provide test_code or set generate_default_test=True")
+            raise ValueError(
+                "No test code: provide test_code or set generate_default_test=True"
+            )
         self._has_multiple_tests = len(test_code_list) > 1
 
         # Log inputs

--- a/triton_kernel_agent/agent.py
+++ b/triton_kernel_agent/agent.py
@@ -440,18 +440,24 @@ def kernel_function(*args, **kwargs):
         return kernels
 
     def generate_kernel(
-        self, problem_description: str, test_code: str | None = None
+        self,
+        problem_description: str,
+        test_code: str | None = None,
+        generate_default_test: bool = True,
     ) -> dict[str, Any]:
         """
         Generate an optimized Triton kernel for the given problem.
 
         Args:
             problem_description: Description of the kernel to generate
-            test_code: Optional test code (generated if not provided)
-                      The test code should:
+            test_code: Optional additional test code string.
+                      Each test should:
                       1. Import the kernel function: from kernel import kernel_function
                       2. Test the kernel and return True/False
                       3. Exit with code 0 on success, 1 on failure
+            generate_default_test: If True (default), auto-generate a primary
+                      test using the LLM. The generated test runs before any
+                      provided ``test_code``.
 
         Returns:
             Dictionary with results including successful kernel
@@ -460,12 +466,17 @@ def kernel_function(*args, **kwargs):
         self.logger.info("Starting kernel generation")
         self.logger.info(f"Problem: {problem_description[:100]}...")
 
-        # Use provided test code if available, otherwise generate it
-        if test_code:
-            self.logger.info("Using provided test code")
-        else:
-            test_code = self._generate_test(problem_description, None)
-            self.logger.info("Generated test code using LLM")
+        # Normalize test_code to list[str]
+        test_code_list: list[str] = []
+        if generate_default_test:
+            generated = self._generate_test(problem_description, None)
+            self.logger.info("Generated default test code using LLM")
+            test_code_list.append(generated)
+        if test_code is not None:
+            self.logger.info("Appending provided test code")
+            test_code_list.append(test_code)
+        if not test_code_list:
+            raise ValueError("No test code: provide test_code or set generate_default_test=True")
 
         # Log inputs
         import time
@@ -481,10 +492,12 @@ def kernel_function(*args, **kwargs):
         with open(session_dir / "problem.txt", "w") as f:
             f.write(problem_description)
         with open(session_dir / "test.py", "w") as f:
-            f.write(test_code)
+            f.write(test_code_list[0])
 
-        # Generate kernel seeds
-        kernel_seeds = self._generate_kernel_seeds(problem_description, test_code)
+        # Generate kernel seeds (uses primary test for context)
+        kernel_seeds = self._generate_kernel_seeds(
+            problem_description, test_code_list[0]
+        )
 
         # Save seeds
         for i, kernel in enumerate(kernel_seeds):
@@ -494,7 +507,7 @@ def kernel_function(*args, **kwargs):
         # Run parallel verification with session directory for worker logs
         result = self.manager.run_verification(
             kernel_seeds=kernel_seeds,
-            test_code=test_code,
+            test_code=test_code_list,
             problem_description=problem_description,
             session_log_dir=session_dir,
         )

--- a/triton_kernel_agent/agent.py
+++ b/triton_kernel_agent/agent.py
@@ -27,6 +27,7 @@ from .manager import WorkerManager
 from .prompt_manager import PromptManager
 from utils.providers import BaseProvider, get_model_provider
 from triton_kernel_agent.platform_config import PlatformConfig, get_platform
+from triton_kernel_agent.worker_util import format_test_code_for_llm
 
 
 class TritonKernelAgent:
@@ -126,7 +127,10 @@ class TritonKernelAgent:
         self.logger = logging.getLogger("TritonKernelAgent")
 
     def _extract_code_from_response(
-        self, response_text: str, language: str = "python"
+        self,
+        response_text: str,
+        language: str = "python",
+        prefer_kernel_function: bool = False,
     ) -> str | None:
         """
         Extract code from LLM response text.
@@ -134,6 +138,11 @@ class TritonKernelAgent:
         Args:
             response_text: The full LLM response text
             language: The expected language (default: python)
+            prefer_kernel_function: When True and multiple code blocks are
+                found, prefer the block that defines ``kernel_function``
+                (falling back to the longest block).  Use this when the
+                prompt contains additional test code that the LLM may echo
+                back.
 
         Returns:
             Extracted code or None if no valid code block found
@@ -146,16 +155,21 @@ class TritonKernelAgent:
         pattern = rf"```{language}\s*\n(.*?)```"
         matches = re.findall(pattern, response_text, re.DOTALL)
 
-        if matches:
-            # Return the first match (largest code block)
-            return matches[0].strip()
-
-        # Try generic code blocks without language marker
-        pattern = r"```\s*\n(.*?)```"
-        matches = re.findall(pattern, response_text, re.DOTALL)
+        if not matches:
+            # Try generic code blocks without language marker
+            pattern = r"```\s*\n(.*?)```"
+            matches = re.findall(pattern, response_text, re.DOTALL)
 
         if matches:
-            # Return the first match
+            if prefer_kernel_function and len(matches) > 1:
+                # When additional tests are in the prompt the LLM may echo
+                # wrapper code.  Prefer the block defining kernel_function.
+                for block in matches:
+                    if re.search(r"\bdef\s+kernel_function\b", block):
+                        return block.strip()
+                # Fallback: return the longest block
+                return max(matches, key=len).strip()
+            # Default: return the first match
             return matches[0].strip()
 
         # If no code blocks found, check if the entire response looks like code
@@ -369,7 +383,10 @@ if __name__ == "__main__":
                     )
 
                     for i, response in enumerate(responses):
-                        kernel_code = self._extract_code_from_response(response.content)
+                        kernel_code = self._extract_code_from_response(
+                            response.content,
+                            prefer_kernel_function=self._has_multiple_tests,
+                        )
                         if kernel_code:
                             kernels.append(kernel_code)
                         else:
@@ -384,7 +401,10 @@ if __name__ == "__main__":
                             max_tokens=max_completion_tokens,
                             temperature=0.8 + (i * 0.1),
                         )
-                        kernel_code = self._extract_code_from_response(response_text)
+                        kernel_code = self._extract_code_from_response(
+                            response_text,
+                            prefer_kernel_function=self._has_multiple_tests,
+                        )
 
                         if kernel_code:
                             kernels.append(kernel_code)
@@ -477,6 +497,7 @@ def kernel_function(*args, **kwargs):
             test_code_list.append(test_code)
         if not test_code_list:
             raise ValueError("No test code: provide test_code or set generate_default_test=True")
+        self._has_multiple_tests = len(test_code_list) > 1
 
         # Log inputs
         import time
@@ -494,9 +515,9 @@ def kernel_function(*args, **kwargs):
         with open(session_dir / "test.py", "w") as f:
             f.write(test_code_list[0])
 
-        # Generate kernel seeds (uses primary test for context)
+        # Generate kernel seeds (all tests as LLM context, with labels)
         kernel_seeds = self._generate_kernel_seeds(
-            problem_description, test_code_list[0]
+            problem_description, format_test_code_for_llm(test_code_list)
         )
 
         # Save seeds

--- a/triton_kernel_agent/agent.py
+++ b/triton_kernel_agent/agent.py
@@ -514,8 +514,9 @@ def kernel_function(*args, **kwargs):
 
         with open(session_dir / "problem.txt", "w") as f:
             f.write(problem_description)
-        with open(session_dir / "test.py", "w") as f:
-            f.write(test_code_list[0])
+        for i, test_code in enumerate(test_code_list):
+            with open(session_dir / f"test_{i}.py", "w") as f:
+                f.write(test_code)
 
         # Generate kernel seeds (all tests as LLM context, with labels)
         kernel_seeds = self._generate_kernel_seeds(

--- a/triton_kernel_agent/manager.py
+++ b/triton_kernel_agent/manager.py
@@ -117,7 +117,7 @@ class WorkerManager:
     def run_verification(
         self,
         kernel_seeds: list[str],
-        test_code: str,
+        test_code: list[str],
         problem_description: str,
         session_log_dir: Path | None = None,
     ) -> dict[str, Any | None]:
@@ -126,7 +126,7 @@ class WorkerManager:
 
         Args:
             kernel_seeds: List of initial kernel implementations
-            test_code: Test code to verify kernel correctness
+            test_code: List of test code strings (primary + additional tests)
             problem_description: Description of the problem
             session_log_dir: Optional session directory for worker logs
 
@@ -224,7 +224,7 @@ class WorkerManager:
 def worker_process(
     worker_id: int,
     kernel_code: str,
-    test_code: str,
+    test_code: list[str],
     problem_description: str,
     workdir: Path,
     log_dir: Path,

--- a/triton_kernel_agent/opt_manager.py
+++ b/triton_kernel_agent/opt_manager.py
@@ -287,8 +287,7 @@ class OptimizationManager:
             initial_kernel: Starting kernel code
             problem_file: Path to problem.py defining Model and get_inputs()
             test_code: Test code for correctness verification. Can be a single
-                string or a list where ``[0]`` is the primary test and ``[1:]``
-                are additional tests chained sequentially.
+                string or a list.
             max_rounds: Override max_rounds (optional)
             **kwargs: Additional kwargs (reserved for future use)
 

--- a/triton_kernel_agent/opt_manager.py
+++ b/triton_kernel_agent/opt_manager.py
@@ -356,7 +356,11 @@ class OptimizationManager:
 
             # 2. Spawn workers
             results = self._run_workers(
-                candidates, round_num, problem_file, test_code, pytorch_baseline,
+                candidates,
+                round_num,
+                problem_file,
+                test_code,
+                pytorch_baseline,
             )
 
             # 3. Update strategy with results

--- a/triton_kernel_agent/opt_manager.py
+++ b/triton_kernel_agent/opt_manager.py
@@ -277,7 +277,7 @@ class OptimizationManager:
         self,
         initial_kernel: str,
         problem_file: Path | str,
-        test_code: str,
+        test_code: str | list[str],
         max_rounds: int | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
@@ -286,7 +286,9 @@ class OptimizationManager:
         Args:
             initial_kernel: Starting kernel code
             problem_file: Path to problem.py defining Model and get_inputs()
-            test_code: Test code for correctness verification
+            test_code: Test code for correctness verification. Can be a single
+                string or a list where ``[0]`` is the primary test and ``[1:]``
+                are additional tests chained sequentially.
             max_rounds: Override max_rounds (optional)
             **kwargs: Additional kwargs (reserved for future use)
 
@@ -300,6 +302,10 @@ class OptimizationManager:
         """
         max_rounds = max_rounds or self.max_rounds
         problem_file = Path(problem_file)
+
+        # Normalize test_code to list
+        if isinstance(test_code, str):
+            test_code = [test_code]
 
         self.logger.info("=" * 80)
         self.logger.info("STARTING OPTIMIZATION")
@@ -350,7 +356,7 @@ class OptimizationManager:
 
             # 2. Spawn workers
             results = self._run_workers(
-                candidates, round_num, problem_file, test_code, pytorch_baseline
+                candidates, round_num, problem_file, test_code, pytorch_baseline,
             )
 
             # 3. Update strategy with results
@@ -419,7 +425,7 @@ class OptimizationManager:
         self,
         initial_kernel: str,
         problem_file: Path,
-        test_code: str,
+        test_code: list[str],
     ) -> bool:
         """Verify the initial kernel passes correctness before optimization."""
         return self.verifier.verify(initial_kernel, problem_file, test_code)
@@ -439,7 +445,7 @@ class OptimizationManager:
         candidates: list[dict[str, Any]],
         round_num: int,
         problem_file: Path,
-        test_code: str,
+        test_code: list[str],
         pytorch_baseline: float,
     ) -> list[dict[str, Any]]:
         """Spawn workers for each candidate and collect results."""

--- a/triton_kernel_agent/opt_worker.py
+++ b/triton_kernel_agent/opt_worker.py
@@ -350,7 +350,7 @@ class OptimizationWorker:
         self,
         kernel_code: str,
         problem_file: Path,
-        test_code: str,
+        test_code: str | list[str],
         known_kernel_time: float | None = None,
         max_opt_rounds: int | None = None,
     ) -> tuple[bool, str, dict[str, Any]]:
@@ -360,7 +360,9 @@ class OptimizationWorker:
         Args:
             kernel_code: Initial kernel code to optimize
             problem_file: Path to problem file defining Model and get_inputs()
-            test_code: Test code for correctness verification
+            test_code: Test code for correctness verification. Can be a single
+                string or a list where ``[0]`` is the primary test and ``[1:]``
+                are additional tests.
             known_kernel_time: Known baseline time in ms (skip initial benchmark)
             max_opt_rounds: Maximum optimization rounds (defaults to self.max_rounds)
 
@@ -369,6 +371,10 @@ class OptimizationWorker:
         """
         if max_opt_rounds is None:
             max_opt_rounds = self.max_rounds
+
+        # Normalize test_code to list
+        if isinstance(test_code, str):
+            test_code = [test_code]
 
         self.logger.info(f"Starting optimization (worker {self.worker_id})")
 

--- a/triton_kernel_agent/opt_worker_component/orchestrator/optimization_orchestrator.py
+++ b/triton_kernel_agent/opt_worker_component/orchestrator/optimization_orchestrator.py
@@ -312,7 +312,7 @@ class OptimizationOrchestrator:
         self,
         kernel_code: str,
         problem_file: Path,
-        test_code: str,
+        test_code: list[str],
         known_kernel_time: float | None = None,
         max_opt_rounds: int = 5,
     ) -> tuple[bool, str, dict[str, Any]]:
@@ -322,7 +322,7 @@ class OptimizationOrchestrator:
         Args:
             kernel_code: Initial kernel code
             problem_file: Path to problem file
-            test_code: Test code for verification
+            test_code: List of test code strings (primary + additional tests)
             known_kernel_time: Known performance of kernel_code in ms
             max_opt_rounds: Maximum optimization rounds
 
@@ -479,7 +479,7 @@ class OptimizationOrchestrator:
 
             # Verify and refine
             success, optimized_kernel, verify_error = self._verify_and_refine(
-                optimized_kernel, test_code, problem_description, round_num
+                optimized_kernel, test_code, problem_description, round_num,
             )
             if not success:
                 error_feedback = (
@@ -880,7 +880,7 @@ class OptimizationOrchestrator:
     def _verify_and_refine(
         self,
         optimized_kernel: str,
-        test_code: str,
+        test_code: list[str],
         problem_description: str,
         round_num: int,
     ) -> tuple[bool, str, str]:

--- a/triton_kernel_agent/opt_worker_component/orchestrator/optimization_orchestrator.py
+++ b/triton_kernel_agent/opt_worker_component/orchestrator/optimization_orchestrator.py
@@ -479,7 +479,10 @@ class OptimizationOrchestrator:
 
             # Verify and refine
             success, optimized_kernel, verify_error = self._verify_and_refine(
-                optimized_kernel, test_code, problem_description, round_num,
+                optimized_kernel,
+                test_code,
+                problem_description,
+                round_num,
             )
             if not success:
                 error_feedback = (

--- a/triton_kernel_agent/platform/interfaces.py
+++ b/triton_kernel_agent/platform/interfaces.py
@@ -34,14 +34,14 @@ class KernelVerifier(ABC):
         self,
         kernel_code: str,
         problem_file: Path,
-        test_code: str,
+        test_code: list[str],
     ) -> bool:
         """Check that *kernel_code* produces correct results.
 
         Args:
             kernel_code: Kernel source code to verify.
             problem_file: Path to ``problem.py`` defining Model and get_inputs().
-            test_code: Test source code for correctness checking.
+            test_code: List of test code strings (primary + additional tests).
 
         Returns:
             ``True`` if the kernel passes verification.
@@ -109,7 +109,7 @@ class WorkerRunner(ABC):
         candidates: list[dict[str, Any]],
         round_num: int,
         problem_file: Path,
-        test_code: str,
+        test_code: list[str],
         pytorch_baseline: float,
         shared_history: list[dict],
         shared_reflexions: list[dict],
@@ -133,7 +133,7 @@ class WorkerRunner(ABC):
             candidates: Candidate specs from the search strategy.
             round_num: Current round number.
             problem_file: Path to ``problem.py``.
-            test_code: Test code for correctness verification.
+            test_code: List of test code strings (primary + additional tests).
             pytorch_baseline: PyTorch eager baseline time in ms.
             shared_history: Recent optimization attempt history.
             shared_reflexions: Recent reflexion entries.

--- a/triton_kernel_agent/platform/noop.py
+++ b/triton_kernel_agent/platform/noop.py
@@ -55,7 +55,7 @@ class NoOpVerifier(KernelVerifier):
         self,
         kernel_code: str,
         problem_file: Path,
-        test_code: str,
+        test_code: list[str],
     ) -> bool:
         logger.info("[noop] Skipping verification — returning True")
         return True
@@ -111,7 +111,7 @@ class NoOpWorkerRunner(WorkerRunner):
         candidates: list[dict[str, Any]],
         round_num: int,
         problem_file: Path,
-        test_code: str,
+        test_code: list[str],
         pytorch_baseline: float,
         shared_history: list[dict],
         shared_reflexions: list[dict],

--- a/triton_kernel_agent/platform/nvidia.py
+++ b/triton_kernel_agent/platform/nvidia.py
@@ -57,7 +57,7 @@ class NvidiaVerifier(KernelVerifier):
         self,
         kernel_code: str,
         problem_file: Path,
-        test_code: str,
+        test_code: list[str],
     ) -> bool:
         from triton_kernel_agent.worker import VerificationWorker
 
@@ -207,7 +207,7 @@ class NvidiaWorkerRunner(WorkerRunner):
         candidates: list[dict[str, Any]],
         round_num: int,
         problem_file: Path,
-        test_code: str,
+        test_code: list[str],
         pytorch_baseline: float,
         shared_history: list[dict],
         shared_reflexions: list[dict],
@@ -293,7 +293,7 @@ def _nvidia_worker_process(
     known_time: float,
     parent_id: str,
     problem_file: Path,
-    test_code: str,
+    test_code: list[str],
     workdir: Path,
     log_dir: Path,
     result_queue: mp.Queue,

--- a/triton_kernel_agent/worker.py
+++ b/triton_kernel_agent/worker.py
@@ -166,6 +166,7 @@ class VerificationWorker:
         # Setup files
         self.kernel_file = self.workdir / "kernel.py"
         self.test_file = self.workdir / "test_kernel.py"
+        self.additional_test_files: list[Path] = []
 
         # History for LLM context
         self.history = deque(maxlen=history_size)
@@ -252,17 +253,30 @@ class VerificationWorker:
         self.kernel_file.write_text(kernel_code)
         self.logger.info("Updated kernel file")
 
-    def _write_files(self, kernel_code: str, test_code: str):
+    def _write_files(self, kernel_code: str, test_code: list[str]):
         """Write kernel and test code to files.
 
         Note: The test code should import the kernel function from the kernel file:
             from kernel import kernel_function
 
         Both files are written to the same directory (workdir).
+
+        Args:
+            kernel_code: The kernel source code.
+            test_code: List of test code strings. ``test_code[0]`` is the
+                primary test written to ``test_kernel.py``; any subsequent
+                entries are written to ``test_extra_{i}_kernel.py``.
         """
         self.kernel_file.write_text(kernel_code)
-        self.test_file.write_text(test_code)
-        self.logger.info("Wrote kernel and test files")
+        self.test_file.write_text(test_code[0])
+        self.additional_test_files = []
+        for i, extra in enumerate(test_code[1:]):
+            extra_file = self.workdir / f"test_extra_{i}_kernel.py"
+            extra_file.write_text(extra)
+            self.additional_test_files.append(extra_file)
+        self.logger.info(
+            "Wrote kernel and %d test file(s)", 1 + len(self.additional_test_files)
+        )
 
     def _strip_comments_and_strings(self, code: str) -> str:
         """Remove comments and docstrings to avoid false positives when scanning code."""
@@ -280,6 +294,10 @@ class VerificationWorker:
     def _run_test(self) -> tuple[bool, str, str]:
         """
         Run the test script and capture results.
+
+        After the primary test passes, any additional test files in
+        ``self.additional_test_files`` are chained sequentially (``&&``
+        semantics).
 
         Returns:
             Tuple of (success, stdout, stderr)
@@ -304,8 +322,25 @@ class VerificationWorker:
                     result.returncode,
                     result.stderr[:2000],
                 )
+                return False, result.stdout, result.stderr
 
-            return success, result.stdout, result.stderr
+            # Chain additional tests if present
+            for extra_file in self.additional_test_files:
+                if not extra_file.exists():
+                    continue
+                extra = subprocess.run(
+                    [sys.executable, str(extra_file)],
+                    cwd=str(self.workdir),
+                    capture_output=True,
+                    text=True,
+                    timeout=self.test_timeout_s,
+                )
+                if extra.returncode != 0:
+                    self.logger.error("Additional test %s failed", extra_file.name)
+                    return False, extra.stdout, extra.stderr
+                self.logger.info("Additional test %s passed", extra_file.name)
+
+            return True, result.stdout, result.stderr
 
         except subprocess.TimeoutExpired:
             self.logger.error("Test timed out")
@@ -434,7 +469,7 @@ class VerificationWorker:
     def run(
         self,
         kernel_code: str,
-        test_code: str,
+        test_code: list[str],
         problem_description: str,
         success_event: mp.Event,
     ) -> dict[str, Any]:
@@ -443,7 +478,7 @@ class VerificationWorker:
 
         Args:
             kernel_code: Initial kernel implementation
-            test_code: Test code to verify kernel
+            test_code: List of test code strings (primary + additional tests)
             problem_description: Problem description for context
             success_event: Shared event to check if another worker succeeded
 
@@ -469,13 +504,13 @@ class VerificationWorker:
 
             # Write files - test only on first round, kernel every round
             if round_num == 0:
-                # First round: write both kernel and test
+                # First round: write both kernel and test(s)
                 self._write_files(current_kernel, test_code)
             else:
                 # Subsequent rounds: only update kernel, test remains unchanged
                 self._write_kernel(current_kernel)
 
-            # Run verification
+            # Run verification (additional tests chained automatically by _run_test)
             success, stdout, stderr, violation = self._single_verification_pass(
                 current_kernel
             )
@@ -488,7 +523,7 @@ class VerificationWorker:
                     "history": list(self.history),
                 }
                 current_kernel = self._refine_kernel(
-                    current_kernel, error_info, problem_description, test_code
+                    current_kernel, error_info, problem_description, test_code[0]
                 )
                 continue
 
@@ -515,7 +550,7 @@ class VerificationWorker:
             }
 
             current_kernel = self._refine_kernel(
-                current_kernel, error_info, problem_description, test_code
+                current_kernel, error_info, problem_description, test_code[0]
             )
 
         # Max rounds reached without success
@@ -547,7 +582,10 @@ class VerificationWorker:
         success, stdout, stderr = (
             self._run_test()
             if os.getenv("KA_PROCESS_USE_SYS_EXECUTABLE", "1") == "1"
-            else _run_test_multiprocess(self.logger, self.workdir, self.test_file)
+            else _run_test_multiprocess(
+                self.logger, self.workdir, self.test_file,
+                additional_test_files=self.additional_test_files,
+            )
         )
 
         return success, stdout, stderr, None
@@ -555,7 +593,7 @@ class VerificationWorker:
     def verify_with_refinement(
         self,
         kernel_code: str,
-        test_code: str,
+        test_code: list[str],
         problem_description: str,
         max_refine_attempts: int = 3,
     ) -> tuple[bool, str, str]:
@@ -567,7 +605,7 @@ class VerificationWorker:
 
         Args:
             kernel_code: Kernel code to verify
-            test_code: Test code for verification
+            test_code: List of test code strings (primary + additional tests)
             problem_description: Problem description for refinement context
             max_refine_attempts: Maximum refinement attempts if verification fails
 
@@ -579,10 +617,10 @@ class VerificationWorker:
         """
         current_kernel = kernel_code
 
-        # Write files for testing
+        # Write files for testing (primary + additional tests)
         self._write_files(current_kernel, test_code)
 
-        # Initial verification
+        # Initial verification (additional tests chained automatically by _run_test)
         success, stdout, stderr, violation = self._single_verification_pass(
             current_kernel
         )
@@ -614,7 +652,7 @@ class VerificationWorker:
 
             # Refine kernel
             refined_kernel = self._refine_kernel(
-                current_kernel, error_info, problem_description, test_code
+                current_kernel, error_info, problem_description, test_code[0]
             )
 
             # Write and test refined kernel

--- a/triton_kernel_agent/worker.py
+++ b/triton_kernel_agent/worker.py
@@ -517,7 +517,10 @@ class VerificationWorker:
                     "history": list(self.history),
                 }
                 current_kernel = self._refine_kernel(
-                    current_kernel, error_info, problem_description, format_test_code_for_llm(test_code)
+                    current_kernel,
+                    error_info,
+                    problem_description,
+                    format_test_code_for_llm(test_code),
                 )
                 continue
 
@@ -544,7 +547,10 @@ class VerificationWorker:
             }
 
             current_kernel = self._refine_kernel(
-                current_kernel, error_info, problem_description, format_test_code_for_llm(test_code)
+                current_kernel,
+                error_info,
+                problem_description,
+                format_test_code_for_llm(test_code),
             )
 
         # Max rounds reached without success
@@ -577,7 +583,9 @@ class VerificationWorker:
             self._run_test()
             if os.getenv("KA_PROCESS_USE_SYS_EXECUTABLE", "1") == "1"
             else _run_test_multiprocess(
-                self.logger, self.workdir, self.test_files,
+                self.logger,
+                self.workdir,
+                self.test_files,
             )
         )
 
@@ -646,7 +654,10 @@ class VerificationWorker:
 
             # Refine kernel
             refined_kernel = self._refine_kernel(
-                current_kernel, error_info, problem_description, format_test_code_for_llm(test_code)
+                current_kernel,
+                error_info,
+                problem_description,
+                format_test_code_for_llm(test_code),
             )
 
             # Write and test refined kernel

--- a/triton_kernel_agent/worker.py
+++ b/triton_kernel_agent/worker.py
@@ -166,8 +166,7 @@ class VerificationWorker:
 
         # Setup files
         self.kernel_file = self.workdir / "kernel.py"
-        self.test_file = self.workdir / "test_kernel.py"
-        self.additional_test_files: list[Path] = []
+        self.test_files: list[Path] = []
 
         # History for LLM context
         self.history = deque(maxlen=history_size)
@@ -282,15 +281,13 @@ class VerificationWorker:
                 entries are written to ``test_extra_{i}_kernel.py``.
         """
         self.kernel_file.write_text(kernel_code)
-        self.test_file.write_text(test_code[0])
-        self.additional_test_files = []
-        for i, extra in enumerate(test_code[1:]):
-            extra_file = self.workdir / f"test_extra_{i}_kernel.py"
-            extra_file.write_text(extra)
-            self.additional_test_files.append(extra_file)
-        self.logger.info(
-            "Wrote kernel and %d test file(s)", 1 + len(self.additional_test_files)
-        )
+        self.test_files = []
+        for i, code in enumerate(test_code):
+            name = "test_kernel.py" if i == 0 else f"test_extra_{i}_kernel.py"
+            path = self.workdir / name
+            path.write_text(code)
+            self.test_files.append(path)
+        self.logger.info("Wrote kernel and %d test file(s)", len(self.test_files))
 
     def _strip_comments_and_strings(self, code: str) -> str:
         """Remove comments and docstrings to avoid false positives when scanning code."""
@@ -307,52 +304,31 @@ class VerificationWorker:
 
     def _run_test(self) -> tuple[bool, str, str]:
         """
-        Run the test script and capture results.
-
-        After the primary test passes, any additional test files in
-        ``self.additional_test_files`` are chained sequentially (``&&``
-        semantics).
+        Run all test scripts sequentially (``&&`` semantics).
 
         Returns:
             Tuple of (success, stdout, stderr)
         """
-        cmd = [sys.executable, str(self.test_file)]
-
         try:
-            result = subprocess.run(
-                cmd,
-                cwd=str(self.workdir),
-                capture_output=True,
-                text=True,
-                timeout=self.test_timeout_s,
-            )
-
-            success = result.returncode == 0
-            if success:
-                self.logger.info("Test passed")
-            else:
-                self.logger.error(
-                    "Test failed. Exit code: %s, stderr: %s",
-                    result.returncode,
-                    result.stderr[:2000],
-                )
-                return False, result.stdout, result.stderr
-
-            # Chain additional tests if present
-            for extra_file in self.additional_test_files:
-                if not extra_file.exists():
+            for test_file in self.test_files:
+                if not test_file.exists():
                     continue
-                extra = subprocess.run(
-                    [sys.executable, str(extra_file)],
+                result = subprocess.run(
+                    [sys.executable, str(test_file)],
                     cwd=str(self.workdir),
                     capture_output=True,
                     text=True,
                     timeout=self.test_timeout_s,
                 )
-                if extra.returncode != 0:
-                    self.logger.error("Additional test %s failed", extra_file.name)
-                    return False, extra.stdout, extra.stderr
-                self.logger.info("Additional test %s passed", extra_file.name)
+                if result.returncode != 0:
+                    self.logger.error(
+                        "Test %s failed. Exit code: %s, stderr: %s",
+                        test_file.name,
+                        result.returncode,
+                        result.stderr[:2000],
+                    )
+                    return False, result.stdout, result.stderr
+                self.logger.info("Test %s passed", test_file.name)
 
             return True, result.stdout, result.stderr
 
@@ -601,8 +577,7 @@ class VerificationWorker:
             self._run_test()
             if os.getenv("KA_PROCESS_USE_SYS_EXECUTABLE", "1") == "1"
             else _run_test_multiprocess(
-                self.logger, self.workdir, self.test_file,
-                additional_test_files=self.additional_test_files,
+                self.logger, self.workdir, self.test_files,
             )
         )
 

--- a/triton_kernel_agent/worker.py
+++ b/triton_kernel_agent/worker.py
@@ -27,6 +27,7 @@ from pathlib import Path
 from typing import Any
 
 from triton_kernel_agent.platform_config import get_platform
+from triton_kernel_agent.worker_util import format_test_code_for_llm
 from utils.providers import get_model_provider
 
 from .prompt_manager import PromptManager
@@ -198,7 +199,10 @@ class VerificationWorker:
         self.logger.addHandler(handler)
 
     def _extract_code_from_response(
-        self, response_text: str, language: str = "python"
+        self,
+        response_text: str,
+        language: str = "python",
+        prefer_kernel_function: bool = False,
     ) -> str | None:
         """
         Extract code from LLM response text.
@@ -206,6 +210,11 @@ class VerificationWorker:
         Args:
             response_text: The full LLM response text
             language: The expected language (default: python)
+            prefer_kernel_function: When True and multiple code blocks are
+                found, prefer the block that defines ``kernel_function``
+                (falling back to the longest block).  Use this when the
+                prompt contains additional test code that the LLM may echo
+                back.
 
         Returns:
             Extracted code or None if no valid code block found
@@ -218,16 +227,21 @@ class VerificationWorker:
         pattern = rf"```{language}\s*\n(.*?)```"
         matches = re.findall(pattern, response_text, re.DOTALL)
 
-        if matches:
-            # Return the first match (largest code block)
-            return matches[0].strip()
-
-        # Try generic code blocks without language marker
-        pattern = r"```\s*\n(.*?)```"
-        matches = re.findall(pattern, response_text, re.DOTALL)
+        if not matches:
+            # Try generic code blocks without language marker
+            pattern = r"```\s*\n(.*?)```"
+            matches = re.findall(pattern, response_text, re.DOTALL)
 
         if matches:
-            # Return the first match
+            if prefer_kernel_function and len(matches) > 1:
+                # When additional tests are in the prompt the LLM may echo
+                # wrapper code.  Prefer the block defining kernel_function.
+                for block in matches:
+                    if re.search(r"\bdef\s+kernel_function\b", block):
+                        return block.strip()
+                # Fallback: return the longest block
+                return max(matches, key=len).strip()
+            # Default: return the first match
             return matches[0].strip()
 
         # If no code blocks found, check if the entire response looks like code
@@ -419,7 +433,10 @@ class VerificationWorker:
                 response_text = self._call_llm(messages, max_tokens=20000)
 
                 # Extract refined kernel from response
-                refined_kernel = self._extract_code_from_response(response_text)
+                refined_kernel = self._extract_code_from_response(
+                    response_text,
+                    prefer_kernel_function=getattr(self, "_has_multiple_tests", False),
+                )
 
                 if refined_kernel:
                     self.logger.info(
@@ -486,6 +503,7 @@ class VerificationWorker:
             Dictionary with results
         """
         self.logger.info(f"Starting verification for worker {self.worker_id}")
+        self._has_multiple_tests = len(test_code) > 1
 
         current_kernel = kernel_code
 
@@ -523,7 +541,7 @@ class VerificationWorker:
                     "history": list(self.history),
                 }
                 current_kernel = self._refine_kernel(
-                    current_kernel, error_info, problem_description, test_code[0]
+                    current_kernel, error_info, problem_description, format_test_code_for_llm(test_code)
                 )
                 continue
 
@@ -550,7 +568,7 @@ class VerificationWorker:
             }
 
             current_kernel = self._refine_kernel(
-                current_kernel, error_info, problem_description, test_code[0]
+                current_kernel, error_info, problem_description, format_test_code_for_llm(test_code)
             )
 
         # Max rounds reached without success
@@ -616,6 +634,7 @@ class VerificationWorker:
             - error_feedback: Error message if failed, empty string if success
         """
         current_kernel = kernel_code
+        self._has_multiple_tests = len(test_code) > 1
 
         # Write files for testing (primary + additional tests)
         self._write_files(current_kernel, test_code)
@@ -652,7 +671,7 @@ class VerificationWorker:
 
             # Refine kernel
             refined_kernel = self._refine_kernel(
-                current_kernel, error_info, problem_description, test_code[0]
+                current_kernel, error_info, problem_description, format_test_code_for_llm(test_code)
             )
 
             # Write and test refined kernel

--- a/triton_kernel_agent/worker_util.py
+++ b/triton_kernel_agent/worker_util.py
@@ -214,96 +214,55 @@ def _run_test_process(test_file: Path, workdir: Path, result_queue: mp.Queue) ->
 def _run_test_multiprocess(
     logger: Logger,
     workdir: Path,
-    test_file: Path,
-    additional_test_files: list[Path] | None = None,
+    test_files: list[Path],
 ) -> tuple[bool, str, str]:
     """
-    Run the test script and capture results using multiprocessing.
-
-    After the primary test passes, any *additional_test_files* are chained
-    sequentially in separate ``mp.Process`` calls (``&&`` semantics).
+    Run test scripts sequentially using multiprocessing (``&&`` semantics).
 
     Args:
         logger: Logger instance.
-        workdir: Working directory for the test.
-        test_file: Path to the primary test file.
-        additional_test_files: Optional list of extra test file paths to
-            run after the primary test passes.
+        workdir: Working directory for the tests.
+        test_files: List of test file paths to run in order.
 
     Returns:
         Tuple of (success, stdout, stderr)
     """
-    # Create process to run the test
-    result_queue = mp.Queue()
-    process = mp.Process(
-        target=_run_test_process,
-        args=(test_file, workdir, result_queue),
-    )
-    process.start()
-    process.join(timeout=30)
-
-    # Check if process is still alive (timeout)
-    if process.is_alive():
-        process.terminate()
-        process.join(timeout=5)
-        if process.is_alive():
-            process.kill()
-            process.join()
-
-        logger.error("Test timed out")
-        return False, "", "Test execution timed out after 30 seconds"
-
-    # Get result from queue
-    try:
-        success, stdout, stderr = result_queue.get_nowait()
-        if success:
-            logger.info("Test passed")
-        else:
-            logger.error(
-                "Test failed. Exit code: %s, stderr: %s", process.exitcode, stderr[:500]
-            )
-            return success, stdout, stderr
-    except mp.queues.Empty:
-        error_msg = (
-            f"Test process ended without result. Exit code: {process.exitcode}. "
+    stdout, stderr = "", ""
+    for test_file in test_files:
+        if not test_file.exists():
+            continue
+        result_queue = mp.Queue()
+        process = mp.Process(
+            target=_run_test_process,
+            args=(test_file, workdir, result_queue),
         )
-        logger.error(error_msg)
-        return False, "", error_msg
+        process.start()
+        process.join(timeout=30)
 
-    # Chain additional tests if the primary test passed
-    if success and additional_test_files:
-        for extra_file in additional_test_files:
-            if not extra_file.exists():
-                continue
-            extra_queue = mp.Queue()
-            extra_proc = mp.Process(
-                target=_run_test_process,
-                args=(extra_file, workdir, extra_queue),
-            )
-            extra_proc.start()
-            extra_proc.join(timeout=30)
+        if process.is_alive():
+            process.terminate()
+            process.join(timeout=5)
+            if process.is_alive():
+                process.kill()
+                process.join()
+            logger.error("Test %s timed out", test_file.name)
+            return False, "", f"Test {test_file.name} timed out after 30 seconds"
 
-            if extra_proc.is_alive():
-                extra_proc.terminate()
-                extra_proc.join(timeout=5)
-                if extra_proc.is_alive():
-                    extra_proc.kill()
-                    extra_proc.join()
-                logger.error("Additional test %s timed out", extra_file.name)
-                return False, "", f"Additional test {extra_file.name} timed out after 30 seconds"
-
-            try:
-                extra_ok, extra_out, extra_err = extra_queue.get_nowait()
-                if not extra_ok:
-                    logger.error("Additional test %s failed: %s", extra_file.name, extra_err[:500])
-                    return False, extra_out, extra_err
-                logger.info("Additional test %s passed", extra_file.name)
-            except mp.queues.Empty:
-                error_msg = (
-                    f"Additional test {extra_file.name} ended without result. "
-                    f"Exit code: {extra_proc.exitcode}."
+        try:
+            success, stdout, stderr = result_queue.get_nowait()
+            if not success:
+                logger.error(
+                    "Test %s failed. Exit code: %s, stderr: %s",
+                    test_file.name, process.exitcode, stderr[:500],
                 )
-                logger.error(error_msg)
-                return False, "", error_msg
+                return False, stdout, stderr
+            logger.info("Test %s passed", test_file.name)
+        except mp.queues.Empty:
+            error_msg = (
+                f"Test {test_file.name} ended without result. "
+                f"Exit code: {process.exitcode}."
+            )
+            logger.error(error_msg)
+            return False, "", error_msg
 
-    return success, stdout, stderr
+    return True, stdout, stderr

--- a/triton_kernel_agent/worker_util.py
+++ b/triton_kernel_agent/worker_util.py
@@ -188,10 +188,23 @@ def _run_test_process(test_file: Path, workdir: Path, result_queue: mp.Queue) ->
 
 
 def _run_test_multiprocess(
-    logger: Logger, workdir: Path, test_file: Path
+    logger: Logger,
+    workdir: Path,
+    test_file: Path,
+    additional_test_files: list[Path] | None = None,
 ) -> tuple[bool, str, str]:
     """
     Run the test script and capture results using multiprocessing.
+
+    After the primary test passes, any *additional_test_files* are chained
+    sequentially in separate ``mp.Process`` calls (``&&`` semantics).
+
+    Args:
+        logger: Logger instance.
+        workdir: Working directory for the test.
+        test_file: Path to the primary test file.
+        additional_test_files: Optional list of extra test file paths to
+            run after the primary test passes.
 
     Returns:
         Tuple of (success, stdout, stderr)
@@ -225,10 +238,48 @@ def _run_test_multiprocess(
             logger.error(
                 "Test failed. Exit code: %s, stderr: %s", process.exitcode, stderr[:500]
             )
-        return success, stdout, stderr
+            return success, stdout, stderr
     except mp.queues.Empty:
         error_msg = (
             f"Test process ended without result. Exit code: {process.exitcode}. "
         )
         logger.error(error_msg)
         return False, "", error_msg
+
+    # Chain additional tests if the primary test passed
+    if success and additional_test_files:
+        for extra_file in additional_test_files:
+            if not extra_file.exists():
+                continue
+            extra_queue = mp.Queue()
+            extra_proc = mp.Process(
+                target=_run_test_process,
+                args=(extra_file, workdir, extra_queue),
+            )
+            extra_proc.start()
+            extra_proc.join(timeout=30)
+
+            if extra_proc.is_alive():
+                extra_proc.terminate()
+                extra_proc.join(timeout=5)
+                if extra_proc.is_alive():
+                    extra_proc.kill()
+                    extra_proc.join()
+                logger.error("Additional test %s timed out", extra_file.name)
+                return False, "", f"Additional test {extra_file.name} timed out after 30 seconds"
+
+            try:
+                extra_ok, extra_out, extra_err = extra_queue.get_nowait()
+                if not extra_ok:
+                    logger.error("Additional test %s failed: %s", extra_file.name, extra_err[:500])
+                    return False, extra_out, extra_err
+                logger.info("Additional test %s passed", extra_file.name)
+            except mp.queues.Empty:
+                error_msg = (
+                    f"Additional test {extra_file.name} ended without result. "
+                    f"Exit code: {extra_proc.exitcode}."
+                )
+                logger.error(error_msg)
+                return False, "", error_msg
+
+    return success, stdout, stderr

--- a/triton_kernel_agent/worker_util.py
+++ b/triton_kernel_agent/worker_util.py
@@ -21,6 +21,30 @@ from logging import Logger
 from pathlib import Path
 
 # ------------------------
+# Test-code helpers
+# ------------------------
+
+
+def format_test_code_for_llm(test_code: list[str]) -> str:
+    """Combine test code entries into a single string for LLM prompts.
+
+    The primary test (``test_code[0]``) is included as-is.  Any additional
+    tests are appended with a clear label so the LLM treats them as
+    reference context rather than code to reproduce.
+    """
+    if len(test_code) == 1:
+        return test_code[0]
+    parts = [test_code[0]]
+    for i, extra in enumerate(test_code[1:]):
+        parts.append(
+            f"\n\n# === ADDITIONAL VALIDATION TEST {i + 1} "
+            f"(for reference only — do NOT copy into your kernel) ===\n"
+            + extra
+        )
+    return "\n".join(parts)
+
+
+# ------------------------
 # LLM Utilities
 # ------------------------
 

--- a/triton_kernel_agent/worker_util.py
+++ b/triton_kernel_agent/worker_util.py
@@ -38,8 +38,7 @@ def format_test_code_for_llm(test_code: list[str]) -> str:
     for i, extra in enumerate(test_code[1:]):
         parts.append(
             f"\n\n# === ADDITIONAL VALIDATION TEST {i + 1} "
-            f"(for reference only — do NOT copy into your kernel) ===\n"
-            + extra
+            f"(for reference only — do NOT copy into your kernel) ===\n" + extra
         )
     return "\n".join(parts)
 
@@ -253,7 +252,9 @@ def _run_test_multiprocess(
             if not success:
                 logger.error(
                     "Test %s failed. Exit code: %s, stderr: %s",
-                    test_file.name, process.exitcode, stderr[:500],
+                    test_file.name,
+                    process.exitcode,
+                    stderr[:500],
                 )
                 return False, stdout, stderr
             logger.info("Test %s passed", test_file.name)


### PR DESCRIPTION
**tldr: Add support to still generate tests when a custom one is provided to `TKA.generate_kernel`.**

Currently, when a custom test is provided, the pipeline does not attempt to generate an LLM test for the problem. 
This is fine, but the generated testing is very useful to have even if there is a custom test (e.g. if the custom test is expensive to run or incomplete).

This PR adds support for generating this test via a `generate_default_test` flag. 
  * To support this, the `test_code` signature throughout the repo needed to be updated from `str` to `list[str]`. Most of the files are changed, just change the type for **test_code** from `str` => `list[str]`.

The only interesting changes are: 
* **triton_kernel_agent/agent.py** and **triton_kernel_agent/worker.py**
When multiple tests are provided, code extraction will prefer the code block with `kernel_function` in it. 
Extraction is unchanged for single tests

* **triton_kernel_agent/worker_util.py**
Helper for formatting the additional tests as context
```
f"\n\n# === ADDITIONAL VALIDATION TEST {i + 1} "
            f"(for reference only — do NOT copy into your kernel) ===\n"
```

---
_Note: this does not enable secondary tests for the Fuser path. This would require a separate effort as testing occurs only during `composition` which is after the sub-kernels have already been built_

This use case will be used for integrating auxiliary testing (internally)

--- 

Tested internally via 

```python
result = agent.generate_kernel(
        problem_description=problem_description,
        test_code=submission_test_code,
        generate_default_test=True,
    )

result = agent.generate_kernel(
        problem_description=problem_description,
        test_code=submission_test_code,
        generate_default_test=False,
    )
```