### PR TITLE
Tolerate Nsight Compute warning lines before the CSV header

### DIFF
--- a/kernel_perf_agent/kernel_opt/profiler/ncu_profiler.py
+++ b/kernel_perf_agent/kernel_opt/profiler/ncu_profiler.py
@@ -351,7 +351,18 @@ def load_ncu_metrics(
     if not csv_path.exists():
         raise FileNotFoundError(f"CSV not found: {csv_path}")
 
-    df = pd.read_csv(csv_path, comment="=", low_memory=False)
+    # Nsight Compute may prepend warnings before the CSV header, for example
+    # when it cannot deploy section files under HOME.  Find the real CSV header
+    # instead of letting pandas treat a warning line as the column list.
+    skiprows = 0
+    with csv_path.open() as f:
+        for line in f:
+            stripped = line.lstrip()
+            if stripped.startswith('"ID",') or stripped.startswith("ID,"):
+                break
+            skiprows += 1
+
+    df = pd.read_csv(csv_path, skiprows=skiprows, low_memory=False)
 
     metric_cols = list(columns) if columns is not None else METRIC_COLUMNS
     keep_cols: List[str] = []


### PR DESCRIPTION
Nsight Compute may prepend warning lines before the CSV header (for example when it cannot deploy section files under HOME), which makes pandas treat a warning line as the column list and breaks metric parsing. Scan for the real CSV header ("ID",/ID,) and skip any preceding lines instead of relying on comment="=".