### PR TITLE
Use gpt-5-5 in beam search example config

### DIFF
--- a/examples/configs/beam_search.yaml
+++ b/examples/configs/beam_search.yaml
@@ -24,7 +24,7 @@ num_workers: 4
 strategy_config:
   num_top_kernels: 2
   num_bottlenecks: 2
-openai_model: claude-opus-4.5
+openai_model: gpt-5-5
 high_reasoning_effort: true
 
 # Worker configuration


### PR DESCRIPTION
Bump the example beam_search strategy default model from claude-opus-4.5 to gpt-5-5 (high reasoning effort unchanged). Unknown model names route through the relay provider, so this behaves the same way the previous relay-only default did.