### PR TITLE
docs(github): add PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+## Description
+
+<!-- Briefly describe what this PR changes and why. -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Documentation
+- [ ] Refactor / cleanup
+- [ ] Other:
+
+## Checklist
+
+- [ ] I have read the contributing guidelines.
+- [ ] I have tested this change locally.
+- [ ] I have updated documentation where relevant.
+- [ ] This PR does not introduce any breaking changes (or the description
+      above explains them).
+
+## Related issues
+
+<!-- e.g. Closes #123 -->


### PR DESCRIPTION
Adds a `.github/PULL_REQUEST_TEMPLATE.md` so new PRs come pre-filled with a small checklist. Keeps reviews consistent without being heavy.

The template is short by design â€” happy to expand or trim.